### PR TITLE
chore: wire analytics (GTM GTM-WK4DGNNP)

### DIFF
--- a/src/components/google-tag-manager/index.tsx
+++ b/src/components/google-tag-manager/index.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import Script from 'next/script'
+import { analyticsConfig } from '@/lib/analytics.config'
 
 // Google Tag Manager ID
-const GTM_ID = 'GTM-TQ5H8HPR'
+const GTM_ID = analyticsConfig.gtmId
 
 export default function GoogleTagManager() {
   return (

--- a/src/lib/analytics.config.ts
+++ b/src/lib/analytics.config.ts
@@ -1,0 +1,20 @@
+// Analytics & tracking IDs - the single place to change them.
+//
+// These are NOT secrets. They are public, client-side identifiers baked into
+// the static export and visible in page source anyway. They live here so a
+// forking charity - or an automated assistant - can point the site at its own
+// accounts by editing this one file. Provisioned by FFC workflow 704.
+export const analyticsConfig = {
+  // Google Tag Manager container ID, e.g. 'GTM-ABC1234'.
+  gtmId: 'GTM-WK4DGNNP',
+
+  // Google Analytics 4 measurement ID, e.g. 'G-ABC1234567'. The GA4 tag itself
+  // fires inside the GTM container; this is kept for reference/components.
+  gaMeasurementId: 'G-LYQNB32N7K',
+
+  // Meta (Facebook) Pixel ID.
+  metaPixelId: 'XXXXXXXXXXXXXXX',
+
+  // Microsoft Clarity project ID.
+  clarityProjectId: 'XXXXXXXX',
+} as const


### PR DESCRIPTION
Wires analytics ids into this site (public client-side ids, not secrets).

- GTM container: `GTM-WK4DGNNP` (FFC-owned, via workflow 503)
- GA4 measurement id: `G-LYQNB32N7K` (via workflow 505; GA4 fires inside the GTM container)

Generated by FFC workflow **704. Website - Analytics Wire**. Part of the fleet analytics
rollout (FreeForCharity/FFC-Cloudflare-Automation#629).