### PR TITLE
chore: prettier-ignore generated DEPENDABOT.md

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -29,3 +29,4 @@ playwright-report
 # Other
 .DS_Store
 *.pem
+DEPENDABOT.md


### PR DESCRIPTION
Adds generated DEPENDABOT.md to .prettierignore. prettier 3.9.x reformats this generated ~17KB docs file, breaking prettier --check on every prettier-bump Dependabot PR (and on main once such a bump merges). Ignoring the generated file is version-proof. Automated fix via daily CI/CD triage 2026-07-16.