### PR TITLE
fix: public/CNAME matches the Pages custom domain

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,1 @@
-ffcworkingsite1.org
+legioninthewoods.org


### PR DESCRIPTION
FreeForCharity/FFC-Cloudflare-Automation#740: the Pages binding is legioninthewoods.org but public/CNAME was stale/missing, so the site was built for the wrong host and the smoke drift assertion fails. Sets public/CNAME=legioninthewoods.org; next deploy rebuilds for the real host and the smoke-failure issue auto-closes.